### PR TITLE
fix(definition): missing "decimal" definition

### DIFF
--- a/src/Swagger/Definition/DefinitionModelAbstract.php
+++ b/src/Swagger/Definition/DefinitionModelAbstract.php
@@ -108,6 +108,7 @@ abstract class DefinitionModelAbstract
                 return "integer";
                 break;
             case "BIGINT":
+            case "DECIMAL":
                 return "number";
                 break;
             case "ENUM":


### PR DESCRIPTION
Add the definition "DECIMAL"